### PR TITLE
F2calv/2024 05 enhance container image tagging

### DIFF
--- a/.github/workflows/app-build-dotnet.yml
+++ b/.github/workflows/app-build-dotnet.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       fullSemVer:
         type: string
-        description: e.g. 1.2.3-feature-my-feature.12
+        description: e.g. 1.2.301-feature-my-feature.12
         required: true
       configuration:
         type: string

--- a/.github/workflows/app-build-rust.yml
+++ b/.github/workflows/app-build-rust.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       fullSemVer:
         type: string
-        description: e.g. 1.2.3-feature-my-feature.12
+        description: e.g. 1.2.301-feature-my-feature.12
         required: true
 
 jobs:

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -32,10 +32,6 @@ on:
         type: number
         description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the minor version is 2.
         required: true
-      tag-patch:
-        type: number
-        description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the patch version is 301.
-        required: true
       defaultBranchTag:
         type: string
         description: Default branch tag, e.g. latest
@@ -105,14 +101,11 @@ jobs:
           docker buildx create --name multiarchtest --use
 
           TAGS=()
-          TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}")
-          TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}.${{ inputs.tag-minor }}")
-          if [ '$TAG' != '${{ inputs.tag-major }}.${{ inputs.tag-minor }}.${{ inputs.tag-patch }}' ]; then
-            TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}.${{ inputs.tag-minor }}.${{ inputs.tag-patch }}")
-          fi
           TAGS+=(-t "$REGISTRY/$REPOSITORY:$TAG")
           if [ '${{ github.ref }}' == '${{ inputs.defaultBranch }}' ]; then
             ADDITIONAL_TAG=${{ inputs.defaultBranchTag }}
+            TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}")
+            TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}.${{ inputs.tag-minor }}")
           else
             ADDITIONAL_TAG=${{ inputs.featureBranchTag }}
           fi

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -22,7 +22,7 @@ on:
         default: Dockerfile
       tag:
         type: string
-        description: e.g. 1.2.3-feature-my-feature.12
+        description: e.g. 1.2.301-feature-my-feature.12
         required: true
       defaultBranchTag:
         type: string

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -25,11 +25,11 @@ on:
         description: e.g. 1.2.301-feature-my-feature.12
         required: true
       tag-major:
-        type: number
+        type: string
         description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the major version is 1.
         required: true
       tag-minor:
-        type: number
+        type: string
         description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the minor version is 2.
         required: true
       defaultBranchTag:

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -24,6 +24,18 @@ on:
         type: string
         description: e.g. 1.2.301-feature-my-feature.12
         required: true
+      tag-major:
+        type: number
+        description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the major version is 1.
+        required: true
+      tag-minor:
+        type: number
+        description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the minor version is 2.
+        required: true
+      tag-patch:
+        type: number
+        description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the patch version is 301.
+        required: true
       defaultBranchTag:
         type: string
         description: Default branch tag, e.g. latest
@@ -46,11 +58,10 @@ on:
         default: refs/heads/main
 
       #TODO: this...
-      pushOnlyOnDefaultBranch:
-        type: boolean
-        description: Only push when on the default branch.
-        default: false
-        
+      # pushOnlyOnDefaultBranch:
+      #   type: boolean
+      #   description: Only push when on the default branch.
+      #   default: false
 
 jobs:
   container-image-build:
@@ -94,6 +105,11 @@ jobs:
           docker buildx create --name multiarchtest --use
 
           TAGS=()
+          TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}")
+          TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}.${{ inputs.tag-minor }}")
+          if [ '$TAG' != '${{ inputs.tag-major }}.${{ inputs.tag-minor }}.${{ inputs.tag-patch }}' ]; then
+            TAGS+=(-t "$REGISTRY/$REPOSITORY:${{ inputs.tag-major }}.${{ inputs.tag-minor }}.${{ inputs.tag-patch }}")
+          fi
           TAGS+=(-t "$REGISTRY/$REPOSITORY:$TAG")
           if [ '${{ github.ref }}' == '${{ inputs.defaultBranch }}' ]; then
             ADDITIONAL_TAG=${{ inputs.defaultBranchTag }}

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -26,11 +26,11 @@ on:
         required: true
       tag-major:
         type: string
-        description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the major version is 1.
+        description: If the tag is 1.2.301-feature-my-feature.12 then pass in only the major version, e.g. 1
         required: true
       tag-minor:
         type: string
-        description: e.g. if the tag is 1.2.301-feature-my-feature.12 then the minor version is 2.
+        description: If the tag is 1.2.301-feature-my-feature.12 then pass in only the minor version, e.g. 2
         required: true
       defaultBranchTag:
         type: string

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -10,7 +10,7 @@ on:
         required: true
       repository:
         type: string
-        description: If empty the repository will derive from name of the repo, i.e. gh-user/my-repo-name
+        description: If empty the repository will derive from name of the repo, e.g. gh-user/my-repo-name
         default: ''
       repository-prefix:
         type: string

--- a/.github/workflows/dotnet-publish-nuget.yml
+++ b/.github/workflows/dotnet-publish-nuget.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       BuildConfiguration:
         type: string
-        description: i.e. Debug or Release
+        description: e.g. Debug or Release
         required: true
         default: Release
       #workflow_call boolean input type is boolean
@@ -19,10 +19,10 @@ on:
       #Note: We don't need to pass in GITHUB_TOKEN to a reusable workflow. When a reusable workflow is triggered by a caller workflow, the github context is always associated with the caller workflow. The called workflow is automatically granted access to github.token and secrets.GITHUB_TOKEN.
       #see https://docs.github.com/en/actions/using-workflows/reusing-workflows
       NUGET_API_KEY:
-        description: i.e. secrets.NUGET_API_KEY
+        description: e.g. secrets.NUGET_API_KEY
         required: false
       SONAR_TOKEN:
-        description: i.e. secrets.SONAR_TOKEN
+        description: e.g. secrets.SONAR_TOKEN
         required: false
 
 jobs:

--- a/.github/workflows/gha-gitops-manifest-update.yml
+++ b/.github/workflows/gha-gitops-manifest-update.yml
@@ -33,7 +33,7 @@ on:
         required: true
       fullSemVer:
         type: string
-        description: e.g. 1.2.3-feature-my-feature.12
+        description: e.g. 1.2.301-feature-my-feature.12
         required: true
       git-user-name:
         type: string

--- a/.github/workflows/gha-release-versioning.yml
+++ b/.github/workflows/gha-release-versioning.yml
@@ -62,8 +62,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - #uses: f2calv/gha-release-versioning@v1
-        uses: f2calv/gha-release-versioning@f2calv/2024-05-added-outputs
+      - uses: f2calv/gha-release-versioning@v1
         id: gha-release-versioning
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gha-release-versioning.yml
+++ b/.github/workflows/gha-release-versioning.yml
@@ -33,11 +33,20 @@ on:
         default: true
     outputs:
       semVer:
-        description: e.g. 1.2.3
+        description: e.g. 1.2.301
         value: ${{ jobs.gha-release-versioning.outputs.semVer }}
       fullSemVer:
-        description: e.g. 1.2.3-feature-my-feature.12
+        description: e.g. 1.2.301-feature-my-feature.12
         value: ${{ jobs.gha-release-versioning.outputs.fullSemVer }}
+      major:
+        description: e.g. 1
+        value: ${{ jobs.gha-release-versioning.outputs.major }}
+      minor:
+        description: e.g. 2
+        value: ${{ jobs.gha-release-versioning.outputs.minor }}
+      patch:
+        description: e.g. 301
+        value: ${{ jobs.gha-release-versioning.outputs.patch }}
 
 jobs:
   gha-release-versioning:
@@ -45,6 +54,9 @@ jobs:
     outputs:
       semVer: ${{ steps.gha-release-versioning.outputs.semVer }}
       fullSemVer: ${{ steps.gha-release-versioning.outputs.fullSemVer }}
+      major: ${{ steps.gha-release-versioning.outputs.major }}
+      minor: ${{ steps.gha-release-versioning.outputs.minor }}
+      patch: ${{ steps.gha-release-versioning.outputs.patch }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gha-release-versioning.yml
+++ b/.github/workflows/gha-release-versioning.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - #uses: f2calv/gha-release-versioning@v1
-      uses: f2calv/gha-release-versioning@f2calv/2024-05-added-outputs
+        uses: f2calv/gha-release-versioning@f2calv/2024-05-added-outputs
         id: gha-release-versioning
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gha-release-versioning.yml
+++ b/.github/workflows/gha-release-versioning.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       # GITHUB_TOKEN:
-      #   description: i.e. secrets.GITHUB_TOKEN
+      #   description: e.g. ${{ secrets.GITHUB_TOKEN }}
       #   required: true
       #   type: string
       #Note: We don't need to pass in GITHUB_TOKEN to a reusable workflow. When a reusable workflow is triggered by a caller workflow, the github context is always associated with the caller workflow. The called workflow is automatically granted access to github.token and secrets.GITHUB_TOKEN.
@@ -17,12 +17,12 @@ on:
         type: string
         default: ''
       tag-prefix:
-        description: Prefix the semver, i.e. 1.0.1 or v1.0.1
+        description: Prefix the semver, e.g. 1.0.1 or v1.0.1
         required: false
         type: string
         default: v
       move-major-tag:
-        description: Create and/or move major version tag, i.e. when creating v1.0.2 then move v1 tag up from the v1.0.1 commit.
+        description: Create and/or move major version tag, e.g. when creating v1.0.2 then move v1 tag up from the v1.0.1 commit.
         required: false
         type: boolean
         default: true
@@ -33,10 +33,10 @@ on:
         default: true
     outputs:
       semVer:
-        description: i.e. 1.2.3
+        description: e.g. 1.2.3
         value: ${{ jobs.gha-release-versioning.outputs.semVer }}
       fullSemVer:
-        description: i.e. 1.2.3-feature-my-feature.12
+        description: e.g. 1.2.3-feature-my-feature.12
         value: ${{ jobs.gha-release-versioning.outputs.fullSemVer }}
 
 jobs:
@@ -50,7 +50,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: f2calv/gha-release-versioning@v1
+      - #uses: f2calv/gha-release-versioning@v1
+      uses: f2calv/gha-release-versioning@f2calv/2024-05-added-outputs
         id: gha-release-versioning
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gha-release-versioning.yml
+++ b/.github/workflows/gha-release-versioning.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       # GITHUB_TOKEN:
-      #   description: e.g. ${{ secrets.GITHUB_TOKEN }}
+      #   description: e.g. USD{{ secrets.GITHUB_TOKEN }}
       #   required: true
       #   type: string
       #Note: We don't need to pass in GITHUB_TOKEN to a reusable workflow. When a reusable workflow is triggered by a caller workflow, the github context is always associated with the caller workflow. The called workflow is automatically granted access to github.token and secrets.GITHUB_TOKEN.


### PR DESCRIPTION
- release versioning rwf outputs major, minor & patch version numbers
- container build rwf requires the major and minor version numbers and tags defaultBranch with additional tags like mycontainer:1 and mycontainer:1.2
- corrected English use of e.g. vs i.e.