### PR TITLE
F2calv/2026 03 updates3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,70 @@
+# Copilot Instructions
+
+## GitHub Actions
+
+### General
+
+- Always leave **one blank line between steps** within a job for readability.
+- Pin actions to the **major version tag version by default** (e.g. `actions/checkout@v6`, `softprops/action-gh-release@v2`). Do not use SHA pinning or include minor/patch versions.
+- Set `fetch-depth: 0` on `actions/checkout` whenever GitVersion is used so it can read the full commit history. For lint-only workflows where history is unnecessary, `fetch-depth: 1` is acceptable.
+- Use explicit `permissions` blocks on every job; default to the minimum required (e.g. `contents: read`). Set global workflow-level permissions to `permissions: {}` (deny all) and grant per-job.
+
+### Step Naming
+
+- **One-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
+- **Multi-part setup**: When a setup requires multiple steps, name each step with a `(N of M)` suffix (e.g. `name: setup yq (1 of 3)`, `name: setup yq (2 of 3)`, `name: setup yq (3 of 3)`).
+- **Matrix-based names**: Include matrix variables in step names for identification (e.g. `name: test (${{ matrix.gv-source }}, ${{ matrix.gv-config }})`).
+
+### Naming Conventions
+
+- **Inputs/outputs**: kebab-case (e.g. `image-registry`, `tag-override`, `git-user-name`).
+- **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
+- **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
+
+### YAML Style
+
+- **2-space indentation** for all workflow and action YAML files.
+- Do not quote strings unless YAML requires it (e.g. values containing special characters, reserved words like `true`/`false`/`null`, or strings that could be misinterpreted as another type).
+- For `workflow_dispatch` string inputs that represent booleans, use quoted defaults (e.g. `default: 'true'`).
+- Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
+- One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
+
+### Reusable Workflows
+
+- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
+- **Same repo**: `uses: ./.github/workflows/_filename.yml`
+- **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
+- Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.
+
+### Composite Actions
+
+- Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
+- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
+
+### Security
+
+- Deny all permissions at workflow level (`permissions: {}`), grant only what each job requires.
+- Skip bot-triggered runs conditionally: `if: github.actor != 'dependabot[bot]'`.
+- Pass tokens via `stdin` for registry logins (e.g. `echo "$TOKEN" | docker login --password-stdin`).
+- OCI registry, repository and tag values must be forced to lowercase (e.g. `${IMAGE_REGISTRY,,}`).
+
+### GitVersion
+
+- Always set `fetch-depth: 0` on checkout when GitVersion is in use.
+- Default config file is `GitVersion.yml` in the repository root.
+- Prefer `semVer` for tags and releases; use `fullSemVer` for display and pre-release identifiers.
+
+## Documentation
+
+### README Consistency
+
+- Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
+- **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate GitHub Actions workflow chains. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
+
+## Copilot Workflow
+
+- **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
+
+## Misc
+
+- When detecting new conventions or patterns in the codebase, add them to this document and apply them retroactively where applicable.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@
 
 - Always set `fetch-depth: 0` on checkout when GitVersion is in use.
 - Default config file is `GitVersion.yml` in the repository root.
-- Prefer `semVer` for tags and releases; use `fullSemVer` for display and pre-release identifiers.
+- Prefer `semVer` for tags and releases; use `fullSemVer` (via the `version` output) for build versioning and pre-release identifiers.
 
 ## Documentation
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,7 @@
 
 - Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
 - **Mermaid diagrams**: Use Mermaid diagrams in `README.md` files to illustrate GitHub Actions workflow chains. These diagrams make complex relationships immediately visible and must be kept in sync with the code they describe.
+- **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
 
 ## Copilot Workflow
 

--- a/.github/prompts/summarize-for-pr.prompt.md
+++ b/.github/prompts/summarize-for-pr.prompt.md
@@ -1,0 +1,62 @@
+---
+description: "Create a temporary markdown file summarising all branch changes vs. main/master for PR review"
+agent: "agent"
+---
+
+# Summarize Branch Changes for PR
+
+Create a temporary markdown file in the repository root called `BRANCH_CHANGES.md` that summarises all changes on the current branch compared to the master/main/default branch. This file is intended to aid PR review and should be deleted before merging.
+
+## Input
+
+No explicit input required — the summary is derived from git history and the current Copilot session context.
+
+## Steps
+
+### 1. Gather Git Context
+
+- Determine the current branch name (`git branch --show-current`).
+- Find the merge base with `origin/master`.
+- Collect the commit log between the merge base and HEAD (`git log --oneline`).
+- Collect the diff stat (`git diff --stat`), file change list (`--diff-filter`), and numstat.
+
+### 2. Distil Session Requests (if applicable)
+
+If Copilot session context is available, extract the key user requests that drove the changes and present them as a bullet-point list at the top of the file under a **Copilot Session Requests** heading.
+
+### 3. Produce the Markdown File
+
+Create `BRANCH_CHANGES.md` in the repository root with the following sections:
+
+#### Header
+
+- Branch name, base branch, and current date.
+
+#### Copilot Session Requests
+
+- Bullet list of the user prompts/requests from the current session that led to changes (omit if no session context).
+
+#### Commits
+
+- Table with columns: Hash, Message, Author, Date.
+
+#### Files Changed
+
+- Table with columns: File, Change type (Added/Modified/Deleted), Insertions, Deletions.
+- Summary line: _N files changed, X insertions, Y deletions._
+
+#### Change Details
+
+- One sub-heading per changed file (or logical group of related files).
+- Numbered list of the distinct changes made, written for a reviewer who is unfamiliar with the recent context.
+
+#### Pending Session Work (if applicable)
+
+- Any in-progress or uncommitted work from the current Copilot session that has not yet been committed.
+
+## Guidelines
+
+- Keep descriptions concise but specific — a reviewer should understand _what_ changed and _why_ without reading the diff.
+- Use git data as the source of truth; supplement with session context only for intent and motivation.
+- Do not include the full diff content — summarise it.
+- Mark the file clearly as temporary (mention it should be deleted before merge).

--- a/.github/workflows/app-build-dotnet.yml
+++ b/.github/workflows/app-build-dotnet.yml
@@ -3,9 +3,9 @@ name: _app-build-dotnet
 on:
   workflow_call:
     inputs:
-      fullSemVer:
+      version:
         type: string
-        description: e.g. 1.2.301-feature-my-feature.12
+        description: e.g. 1.2.301-feature-my-feature.12+56
         required: true
       configuration:
         type: string
@@ -47,6 +47,6 @@ jobs:
         run: dotnet restore ${{ inputs.solution-name }} --verbosity minimal ${{ inputs.dotnet-restore-args }}
 
       - name: dotnet build
-        run: dotnet build ${{ inputs.solution-name }} -c ${{ inputs.configuration }} --nologo --no-restore -p:Version='${{ inputs.fullSemVer }}' -p:SourceRevisionId=${{ github.sha }} ${{ inputs.dotnet-build-args }}
+        run: dotnet build ${{ inputs.solution-name }} -c ${{ inputs.configuration }} --nologo --no-restore -p:Version='${{ inputs.version }}' -p:SourceRevisionId=${{ github.sha }} ${{ inputs.dotnet-build-args }}
 
       #TODO: could run dotnet test here, etc...

--- a/.github/workflows/app-build-rust.yml
+++ b/.github/workflows/app-build-rust.yml
@@ -3,9 +3,9 @@ name: _app-build-rust
 on:
   workflow_call:
     inputs:
-      fullSemVer:
+      version:
         type: string
-        description: e.g. 1.2.301-feature-my-feature.12
+        description: e.g. 1.2.301-feature-my-feature.12+56
         required: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches-ignore:
       - "preview/**"
     paths-ignore:
+      - .github/copilot-instructions.md
       - .github/dependabot.yml
       - LICENSE
       - README.md

--- a/.github/workflows/dotnet-publish-nuget.yml
+++ b/.github/workflows/dotnet-publish-nuget.yml
@@ -63,11 +63,15 @@ jobs:
       move-major-tag: false
 
   # gha-sonarqube:
-  #   runs-on: windows-latest
+  #   runs-on: ubuntu-latest
   #   needs: [build]
   #   steps:
-  #     - uses: f2calv/gha-sonarqube-dotnet@v1
+  #     - uses: actions/checkout@v6
   #       with:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  #         configuration: ${{ needs.build.outputs.configuration }}
+  #         fetch-depth: 0
+  #
+  #     - uses: f2calv/gha-sonarqube-dotnet@v2
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         sonar-token: ${{ secrets.SONAR_TOKEN }}
+  #         build-configuration: ${{ inputs.configuration }}

--- a/.github/workflows/gha-gitops-manifest-update.yml
+++ b/.github/workflows/gha-gitops-manifest-update.yml
@@ -3,50 +3,71 @@ name: _gha-gitops-manifest-update
 on:
   workflow_call:
     inputs:
-      registry:
+      #image
+      tag:
+        type: string
+        description: e.g. 1.2.3
+        required: true
+      tag-override:
+        type: string
+        description: e.g. latest, latest-dev
+      image-registry:
         type: string
         description: e.g. ghcr.io/gh-user, xyz.azurecr.io or docker.io
         required: true
-      repository:
+      image-repository:
         type: string
-        description: Accepts multiple deployment names when separated by a space e.g. deploy1 deploy2 deploy3
+        description: e.g. [optional-prefix/]myimage
         required: true
-      repository-prefix:
+      #chart
+      chart-registry:
         type: string
-        description: e.g. prefix/
-        default: ''
-      tag:
+        description: e.g. ghcr.io/gh-user, xyz.azurecr.io or docker.io
+      chart-registry-username:
         type: string
-        description: e.g. latest, latest-dev, 1.2.3
+      chart-registry-password:
+        type: string
+      chart-repository:
+        type: string
+        description: e.g. [optional-prefix/]charts/myname
+      #manifest
+      manifest-paths:
+        type: string
+        description: Space-separated YAML manifests which need to be updated e.g. src/workloads/manifest1.yaml src/workloads/manifest2.yaml
         required: true
-      git-repository:
+      namespace:
+        type: string
+        description: Destination Kubernetes namespace for the application.
+        required: true
+      #tooling
+      devcontainer-path:
+        type: string
+        description: e.g. .devcontainer/devcontainer.json
+        default: .devcontainer/devcontainer.json
+      #git
+      gitops-repo:
         type: string
         description: e.g. gh-user/my-repo-name
-        default: ${{ github.repository }}
-      manifest:
+      gitops-repo-path:
         type: string
-        description: Accepts multiple manifest names (without file extension) when separated by a space e.g. deploy1 deploy2 deploy3 (deploy1.yaml etc...)
-        required: true
-      manifest-path:
+        description: Path where the GitOps repository is checked-out to.
+        default: gitops/
+      gitops-repo-branch:
         type: string
-        description: e.g. src/workloads
-        required: true
-      fullSemVer:
+        description: e.g. main
+        default: main
+      gitops-repo-update:
+        type: boolean
+        description: If 'false' then skips the git operations entirely, e.g. action runs in demo mode
+        default: true
+      gitops-repo-user-name:
         type: string
-        description: e.g. 1.2.301-feature-my-feature.12
-        required: true
-      git-user-name:
+        description: e.g. GitHub Actions Bot
+        default: GitHub Actions Bot
+      gitops-repo-user-email:
         type: string
-        description: e.g. Tom Cruise
-        required: true
-      git-user-email:
-        type: string
-        description: e.g. tom@topgun.com
-        required: true
-    secrets:
-      git-repository-token:
-        description: Git repository authentication token.
-        required: true
+        description: e.g. github-actions[bot]@users.noreply.github.com
+        default: github-actions[bot]@users.noreply.github.com
 
 jobs:
   gha-gitops-manifest-update:
@@ -56,26 +77,28 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          repository: ${{ inputs.git-repository }}
-          token: ${{ secrets.git-repository-token }}
+          repository: ${{ inputs.gitops-repo }}
+          token: ${{ secrets.GH_PAT_GITOPS }}
+          persist-credentials: true
+          path: ${{ inputs.gitops-repo-path }}
 
-      #Note: below workflow code left in place to show how to access a local action from inside a reuseable workflow, i.e. messy!
-      # - uses: actions/checkout@v6
-      #   with:
-      #     fetch-depth: 0
-      #     repository: f2calv/gha-workflows #Note: this repo name
-      #     ref: ${{ github.ref_name }} #Note: assumes that the ref repo has an identical branch name to the calling branch
-      #     path: workflows
-
-      - uses: f2calv/gha-gitops-manifest-update@v1
-        #uses: ./workflows/.github/actions/gha-gitops-manifest-update
+      - name: yaml manifest update
+        uses: f2calv/gha-gitops-manifest-update@f2calv/2026-03-update2
         with:
-          registry: ${{ inputs.registry }}
-          repository: ${{ inputs.repository }}
-          repository-prefix: ${{ inputs.repository-prefix }}
           tag: ${{ inputs.tag }}
-          manifest: ${{ inputs.manifest }}
-          manifest-path: ${{ inputs.manifest-path }}
-          fullSemVer: ${{ inputs.fullSemVer }}
-          git-user-name: ${{ inputs.git-user-name }}
-          git-user-email: ${{ inputs.git-user-email }}
+          tag-override: ${{ inputs.tag-override }}
+          image-registry: ${{ inputs.image-registry }}
+          image-repository: ${{ inputs.image-repository }}
+          chart-registry: ${{ inputs.chart-registry }}
+          chart-registry-username: ${{ inputs.chart-registry-username }}
+          #chart-registry-password: ${{ inputs.chart-registry-password }}
+          chart-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          chart-repository: ${{ inputs.chart-repository }}
+          manifest-paths: ${{ inputs.manifest-paths }}
+          namespace: ${{ inputs.namespace }}
+          devcontainer-path: ${{ inputs.devcontainer-path }}
+          git-repo-update: ${{ inputs.gitops-repo-update }}
+          git-user-name: ${{ inputs.gitops-repo-user-name }}
+          git-user-email: ${{ inputs.gitops-repo-user-email }}
+          git-branch-name: ${{ inputs.gitops-repo-branch }}
+          git-working-directory: ${{ inputs.gitops-repo-path }}

--- a/.github/workflows/gha-gitops-manifest-update.yml
+++ b/.github/workflows/gha-gitops-manifest-update.yml
@@ -51,7 +51,7 @@ on:
       gitops-repo-path:
         type: string
         description: Path where the GitOps repository is checked-out to.
-        default: gitops/
+        default: .
       gitops-repo-branch:
         type: string
         description: e.g. main

--- a/.github/workflows/gha-gitops-manifest-update.yml
+++ b/.github/workflows/gha-gitops-manifest-update.yml
@@ -83,7 +83,7 @@ jobs:
           path: ${{ inputs.gitops-repo-path }}
 
       - name: yaml manifest update
-        uses: f2calv/gha-gitops-manifest-update@f2calv/2026-03-update2
+        uses: f2calv/gha-gitops-manifest-update@v2
         with:
           tag: ${{ inputs.tag }}
           tag-override: ${{ inputs.tag-override }}

--- a/.github/workflows/gha-release-versioning.yml
+++ b/.github/workflows/gha-release-versioning.yml
@@ -41,14 +41,8 @@ on:
         default: actions
     outputs:
       version:
-        description: e.g. 1.2.301
+        description: e.g. 1.2.301-feature-my-feature.12+56
         value: ${{ jobs.gha-release-versioning.outputs.version }}
-      semVer:
-        description: e.g. 1.2.301
-        value: ${{ jobs.gha-release-versioning.outputs.semVer }}
-      fullSemVer:
-        description: e.g. 1.2.301-feature-my-feature.12
-        value: ${{ jobs.gha-release-versioning.outputs.fullSemVer }}
       major:
         description: e.g. 1
         value: ${{ jobs.gha-release-versioning.outputs.major }}
@@ -67,8 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.gha-release-versioning.outputs.version }}
-      semVer: ${{ steps.gha-release-versioning.outputs.semVer }}
-      fullSemVer: ${{ steps.gha-release-versioning.outputs.fullSemVer }}
       major: ${{ steps.gha-release-versioning.outputs.major }}
       minor: ${{ steps.gha-release-versioning.outputs.minor }}
       patch: ${{ steps.gha-release-versioning.outputs.patch }}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,15 +1,15 @@
-mode: MainLine
+mode: ContinuousDeployment
 branches:
   main:
     regex: ^main$
-    tag: ""
+    label: ''
   feature:
     regex: ^features?[/-]
-    tag: useBranchName
+    label: useBranchName
   preview:
     regex: ^preview?[/-]
-    tag: preview-{BranchName}
-    source-branches: ["main"]
+    label: preview-{BranchName}
+    source-branches: [main]
 ignore:
   sha: []
 merge-message-formats: {}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ jobs:
   build:
     uses: f2calv/gha-workflows/.github/workflows/app-build-dotnet.yml@v1
     with:
-      fullSemVer: ${{ needs.versioning.outputs.fullSemVer }}
+      version: ${{ needs.versioning.outputs.version }}
       solution-name: MySolution.slnx
 ```
 
@@ -23,8 +23,8 @@ jobs:
 
 | Workflow | Description | Key Inputs |
 | --- | --- | --- |
-| [App Build .NET](.github/workflows/app-build-dotnet.yml) | Restore, workload restore, build a .NET solution/project. Installs .NET 8/9/10 SDKs. | `fullSemVer` (required), `solution-name`, `configuration`, `dotnet-restore-args`, `dotnet-build-args` |
-| [App Build Rust](.github/workflows/app-build-rust.yml) | Format check, clippy lint, fetch and build a Rust project. | `fullSemVer` (required) |
+| [App Build .NET](.github/workflows/app-build-dotnet.yml) | Restore, workload restore, build a .NET solution/project. Installs .NET 8/9/10 SDKs. | `version` (required), `solution-name`, `configuration`, `dotnet-restore-args`, `dotnet-build-args` |
+| [App Build Rust](.github/workflows/app-build-rust.yml) | Format check, clippy lint, fetch and build a Rust project. | `version` (required) |
 
 ### Containers & Helm
 
@@ -32,7 +32,7 @@ jobs:
 | --- | --- | --- |
 | [Container Image Build](.github/workflows/container-image-build.yml) | Multi-architecture buildx build and push to a container registry (ghcr.io, ACR, Docker Hub). Tags with semver, major, minor and latest. | `registry` (required), `tag` (required), `tag-major` (required), `tag-minor` (required), `platform`, `push-image` |
 | [Helm Chart Package](.github/workflows/helm-chart-package.yml) | Lint, package and push a Helm chart to an OCI registry. Helm version is sourced from `.devcontainer/devcontainer.json`. | `tag` (required), `image-registry` (required), `chart-registry` (required), `chart-repository` (required), `chart-path` |
-| [GitOps Manifest Update](.github/workflows/gha-gitops-manifest-update.yml) | Update image tags in a GitOps repository via [f2calv/gha-gitops-manifest-update](https://github.com/f2calv/gha-gitops-manifest-update). | `registry` (required), `repository` (required), `tag` (required), `manifest` (required), `manifest-path` (required) |
+| [GitOps Manifest Update](.github/workflows/gha-gitops-manifest-update.yml) | Update image tags in a GitOps repository via [f2calv/gha-gitops-manifest-update](https://github.com/f2calv/gha-gitops-manifest-update). | `tag` (required), `image-registry` (required), `image-repository` (required), `manifest-paths` (required), `namespace` (required) |
 
 ### NuGet
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ flowchart LR
     classDef f2calv fill:#dbeafe,stroke:#2563eb,color:#1e3a5f
     W(["_gha-gitops-manifest-update"]) --> J["gha-gitops-manifest-update"]
     J --> A1["actions/checkout@v6"]
-    J --> A2["f2calv/gha-gitops-manifest-update@v1"]
+    J --> A2["f2calv/gha-gitops-manifest-update@v2"]
     class A2 f2calv
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ jobs:
 ### Application Build
 
 | Workflow | Description | Key Inputs |
-|---|---|---|
+| --- | --- | --- |
 | [App Build .NET](.github/workflows/app-build-dotnet.yml) | Restore, workload restore, build a .NET solution/project. Installs .NET 8/9/10 SDKs. | `fullSemVer` (required), `solution-name`, `configuration`, `dotnet-restore-args`, `dotnet-build-args` |
 | [App Build Rust](.github/workflows/app-build-rust.yml) | Format check, clippy lint, fetch and build a Rust project. | `fullSemVer` (required) |
 
 ### Containers & Helm
 
 | Workflow | Description | Key Inputs |
-|---|---|---|
+| --- | --- | --- |
 | [Container Image Build](.github/workflows/container-image-build.yml) | Multi-architecture buildx build and push to a container registry (ghcr.io, ACR, Docker Hub). Tags with semver, major, minor and latest. | `registry` (required), `tag` (required), `tag-major` (required), `tag-minor` (required), `platform`, `push-image` |
 | [Helm Chart Package](.github/workflows/helm-chart-package.yml) | Lint, package and push a Helm chart to an OCI registry. Helm version is sourced from `.devcontainer/devcontainer.json`. | `tag` (required), `image-registry` (required), `chart-registry` (required), `chart-repository` (required), `chart-path` |
 | [GitOps Manifest Update](.github/workflows/gha-gitops-manifest-update.yml) | Update image tags in a GitOps repository via [f2calv/gha-gitops-manifest-update](https://github.com/f2calv/gha-gitops-manifest-update). | `registry` (required), `repository` (required), `tag` (required), `manifest` (required), `manifest-path` (required) |
@@ -37,19 +37,19 @@ jobs:
 ### NuGet
 
 | Workflow | Description | Key Inputs |
-|---|---|---|
+| --- | --- | --- |
 | [.NET Publish NuGet](.github/workflows/dotnet-publish-nuget.yml) | Build, test, pack and push NuGet packages via [f2calv/gha-dotnet-nuget](https://github.com/f2calv/gha-dotnet-nuget). | `configuration`, `execute-tests`, `push-preview` |
 
 ### Release & Versioning
 
 | Workflow | Description | Key Inputs |
-|---|---|---|
+| --- | --- | --- |
 | [Release Versioning](.github/workflows/gha-release-versioning.yml) | Determine a semantic version (via [GitVersion](https://gitversion.net/)), tag the repo and create a GitHub release. | `semVer`, `tag-prefix`, `move-major-tag`, `tag-and-release` |
 
 ### Code Quality
 
 | Workflow | Description | Key Inputs |
-|---|---|---|
+| --- | --- | --- |
 | [Lint](.github/workflows/lint.yml) | Run [pre-commit](https://pre-commit.com/) hooks against all files in the repository. | `pre-commit-version` |
 
 ## Dependency Diagrams


### PR DESCRIPTION
## Copilot Session Requests

- Remove `semVer` and `fullSemVer` as separate action outputs from `gha-release-versioning`; consolidate to a single `version` output backed by `fullSemVer`.
- Rename the `fullSemVer` input to `version` in `app-build-dotnet.yml` and `app-build-rust.yml`.
- Add `.github/copilot-instructions.md` to `paths-ignore` in all CI/test workflows.
- Update `copilot-instructions.md` GitVersion convention across all repos.
- Update `README.md`.

## Commits

| Hash | Message | Author | Date |
| --- | --- | --- | --- |
| 7bfef48 | versioning fix + docs | Alex Vincent | 2026-04-01 |
| 717c709 | update gitops version | Alex Vincent | 2026-04-01 |
| fe956a9 | fix gitops path | Alex Vincent | 2026-04-01 |
| 3ea23dd | misc updates | Alex Vincent | 2026-04-01 |
| 18b854f | update instructions | Alex Vincent | 2026-03-31 |
| 6d0e352 | +semver:feature big gitops update | Alex Vincent | 2026-03-31 |

## Files Changed

| File | Change | Insertions | Deletions |
| --- | --- | --- | --- |
| .github/copilot-instructions.md | Added | 71 | 0 |
| .github/prompts/summarize-for-pr.prompt.md | Added | 62 | 0 |
| .github/workflows/app-build-dotnet.yml | Modified | 3 | 3 |
| .github/workflows/app-build-rust.yml | Modified | 2 | 2 |
| .github/workflows/ci.yml | Modified | 1 | 0 |
| .github/workflows/dotnet-publish-nuget.yml | Modified | 9 | 5 |
| .github/workflows/gha-gitops-manifest-update.yml | Modified | 72 | 49 |
| .github/workflows/gha-release-versioning.yml | Modified | 1 | 9 |
| GitVersion.yml | Modified | 5 | 5 |
| README.md | Modified | 6 | 6 |

_10 files changed, 232 insertions, 79 deletions._

## Change Details

### Versioning output consolidation (`gha-release-versioning.yml`)

1. Removed `semVer` and `fullSemVer` from the reusable workflow's outputs — only `version` (backed by `fullSemVer`) remains.
2. Removed `semVer` and `fullSemVer` from the job-level outputs mapping.
3. Updated the `version` output description to `e.g. 1.2.301-feature-my-feature.12+56`.

### Build workflow input rename (`app-build-dotnet.yml`, `app-build-rust.yml`)

1. Renamed the `fullSemVer` input to `version` in both workflows.
2. Updated the `dotnet build` command in `app-build-dotnet.yml` to reference `inputs.version`.
3. Updated descriptions to include build metadata example (`+56`).

### CI paths-ignore (`ci.yml`)

1. Added `.github/copilot-instructions.md` to `paths-ignore` so documentation-only changes don't trigger builds.

### GitOps manifest update overhaul (`gha-gitops-manifest-update.yml`)

1. Replaced the old input schema (`registry`, `repository`, `repository-prefix`, `manifest`, `manifest-path`, `fullSemVer`, `git-user-name`, `git-user-email`) with a new structured schema split into image, chart, manifest, tooling, and git sections.
2. Added new inputs: `tag-override`, `image-registry`, `image-repository`, `chart-registry`, `chart-registry-username`, `chart-registry-password`, `chart-repository`, `manifest-paths`, `namespace`, `devcontainer-path`, `gitops-repo`, `gitops-repo-path`, `gitops-repo-branch`, `gitops-repo-update`, `gitops-repo-user-name`, `gitops-repo-user-email`.
3. Replaced `secrets.git-repository-token` with `secrets.GH_PAT_GITOPS`.
4. Bumped action from `f2calv/gha-gitops-manifest-update@v1` to `@v2`.
5. Added `persist-credentials: true` and `path` to checkout step.

### NuGet publish SonarQube update (`dotnet-publish-nuget.yml`)

1. Updated commented-out SonarQube job: changed runner from `windows-latest` to `ubuntu-latest`, bumped action to `@v2`, and modernised input names (`github-token`, `sonar-token`, `build-configuration`).

### GitVersion config migration (`GitVersion.yml`)

1. Changed mode from `MainLine` to `ContinuousDeployment`.
2. Replaced v5 `tag:` syntax with v6 `label:` syntax across all branch configs.
3. Changed `source-branches` quoting style from `["main"]` to `[main]`.

### README table formatting (`README.md`)

1. Fixed markdown table separators from `|---|---|---|` to `| --- | --- | --- |` (MD060 compliance).
2. Updated Mermaid diagram: bumped `gha-gitops-manifest-update` reference from `@v1` to `@v2`.

### New files

1. **`.github/copilot-instructions.md`** — Added repository-specific Copilot instructions (GitHub Actions conventions, documentation, workflow guidelines).
2. **`.github/prompts/summarize-for-pr.prompt.md`** — Added a reusable prompt for generating PR change summaries.