### PR TITLE
Add ef-migrations-drift & package-cleanup workflows; split copilot instructions; bump checkout to v7

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ The conventions below always apply, regardless of the file being edited.
 
 - **Test execution**: Never run tests automatically — they may be integration tests requiring extra setup. Always prompt (ideally with a visual yes/no button) before running any tests.
 - **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
+- **Multi-repo commits**: When a single change spans multiple repositories, separate per-repository commit messages are acceptable (but not mandatory). Prefer them where the changes are disconnected, or where one repository should not really "know about" the other (e.g. an app repo and a GitOps repo). A single shared commit message is fine when the change is genuinely coupled.
 
 ## Repository Structure
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,109 +1,22 @@
 # Copilot Instructions
 
 <!-- ── Synced section ─────────────────────────────────────────────────────
-     Everything above the "Project-Specific Overrides" heading is kept
-     identical across all f2calv repositories. Edit once, sync everywhere.
+     This file plus every file under `.github/instructions/` is kept
+     identical across all f2calv GitHub Action repositories. The repo-specific
+     "Project-Specific Overrides" section below is excluded from sync.
+     Edit once, sync everywhere.
      ──────────────────────────────────────────────────────────────────── -->
 
-## GitHub Actions
+## Instruction Files
 
-### General
+Detailed conventions live in scoped instruction files under `.github/instructions/`, auto-applied by file type:
 
-- Always leave **one blank line between steps** within a job for readability.
-- Pin actions to the **major version tag version by default** (e.g. `actions/checkout@v6`, `softprops/action-gh-release@v2`). Do not use SHA pinning or include minor/patch versions.
-- Set `fetch-depth: 0` on `actions/checkout` whenever GitVersion is used so it can read the full commit history. For lint-only workflows where history is unnecessary, `fetch-depth: 1` is acceptable.
-- Use explicit `permissions` blocks on every job; default to the minimum required (e.g. `contents: read`). Set global workflow-level permissions to `permissions: {}` (deny all) and grant per-job.
+| File | Applies to | Covers |
+| --- | --- | --- |
+| `github-actions.instructions.md` | workflows / `action.yml` | GitHub Actions naming, YAML, security, GitVersion |
+| `documentation.instructions.md` | `**/*.md` | README consistency & Mermaid diagrams |
 
-### Step Naming
-
-- **One-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
-- **Multi-part setup**: When a setup requires multiple steps, name each step with a `(N of M)` suffix (e.g. `name: setup yq (1 of 3)`, `name: setup yq (2 of 3)`, `name: setup yq (3 of 3)`).
-- **Matrix-based names**: Include matrix variables in step names for identification (e.g. `name: test (${{ matrix.gv-source }}, ${{ matrix.gv-config }})`).
-
-### Naming Conventions
-
-- **Inputs/outputs**: kebab-case (e.g. `image-registry`, `tag-override`, `git-user-name`).
-- **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
-- **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
-
-### YAML Style
-
-- **2-space indentation** for all workflow and action YAML files.
-- Do not quote strings unless YAML requires it (e.g. values containing special characters, reserved words like `true`/`false`/`null`, or strings that could be misinterpreted as another type).
-- For `workflow_dispatch` string inputs that represent booleans, use quoted defaults (e.g. `default: 'true'`).
-- Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
-- One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
-
-### Reusable Workflows
-
-- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
-- **Same repo**: `uses: ./.github/workflows/_filename.yml`
-- **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
-- Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.
-
-### Composite Actions
-
-- Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
-- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
-
-### Security
-
-- Deny all permissions at workflow level (`permissions: {}`), grant only what each job requires.
-- Skip bot-triggered runs conditionally: `if: github.actor != 'dependabot[bot]'`.
-- Pass tokens via `stdin` for registry logins (e.g. `echo "$TOKEN" | docker login --password-stdin`).
-- OCI registry, repository and tag values must be forced to lowercase (e.g. `${IMAGE_REGISTRY,,}`).
-
-### GitVersion
-
-- Always set `fetch-depth: 0` on checkout when GitVersion is in use.
-- Default config file is `GitVersion.yml` in the repository root.
-- Prefer `semVer` for tags and releases; use `fullSemVer` (via the `version` output) for build versioning and pre-release identifiers.
-
-## Documentation
-
-### README Consistency
-
-- Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
-- **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
-
-### Mermaid Diagrams
-
-Use Mermaid diagrams in `README.md` files to visualize complex relationships and flows. Choose the appropriate diagram type:
-
-#### Diagram Type Selection
-
-- **`flowchart`**: Sequential processes, data flow, event flow, service orchestration, CI/CD pipelines
-  - Direction: Use `TD` (top-down) for vertical flows; `LR` (left-right) for wide workflows
-  - Example: GitHub Actions workflow chains, composite action steps
-
-- **`graph`**: Relationships, dependencies, hierarchies (non-sequential)
-  - Direction: Use `TD` for dependency trees; `LR` for peer relationships
-  - Example: Action dependencies, workflow call chains
-
-#### Standard Headings
-
-Use these consistent heading patterns before Mermaid diagrams:
-
-| Heading | Use For |
-| --- | --- |
-| `## Deployment Flow` | CI/CD pipelines, GitHub Actions workflows, action call chains |
-| `## Dependency Graph` | Action dependencies, workflow relationships |
-
-#### Styling Guidelines
-
-- **Subgraphs**: Group related steps or jobs
-- **Custom styling**: Define `classDef` for highlighting owned vs. third-party actions
-- **Node shapes**:
-  - `[ ]` rectangle (default) - actions, jobs
-  - `([ ])` stadium - workflows
-  - `{ }` diamond - decision points
-
-#### Synchronization
-
-- Mermaid diagrams must stay in sync with action/workflow changes
-- When renaming inputs/outputs, update corresponding diagram nodes
-- When adding/removing action dependencies, update dependency graphs
-- Review all `README.md` diagrams before creating PRs
+The conventions below always apply, regardless of the file being edited.
 
 ## Copilot Workflow
 
@@ -112,8 +25,8 @@ Use these consistent heading patterns before Mermaid diagrams:
 
 ## Misc
 
-- When detecting new conventions or patterns in the codebase, add them to this document and apply them retroactively where applicable.
-- When multiple `copilot-instructions.md` files are available in the workspace, keep them in sync based on the common guidelines in the synced section.
+- When detecting new conventions or patterns in the codebase, add them to the appropriate `.github/instructions/*.instructions.md` file (or this file for cross-cutting workflow rules) and apply them retroactively where applicable.
+- Keep this file and the `.github/instructions/` files in sync across repositories based on the common synced guidelines.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,25 @@ The conventions below always apply, regardless of the file being edited.
 - **Test execution**: Never run tests automatically — they may be integration tests requiring extra setup. Always prompt (ideally with a visual yes/no button) before running any tests.
 - **Preserve git history during renames/moves**: When renaming or relocating files, first perform the rename/move (preferably via `git mv`), then make content edits to the file in its new location/name. This two-step approach preserves git history across the rename. Do not delete-and-recreate files when a rename or move is the intent.
 
+## Repository Structure
+
+Every f2calv repository follows a consistent layout, regardless of language:
+
+- **Root files**: `README.md`, `LICENSE`, `GitVersion.yml`, `.editorconfig`, `.gitattributes`, `.gitignore`, and `.pre-commit-config.yaml` live in the repository root.
+- **Source code** lives under `src/`. *(Exception: GitHub Action repositories keep `action.yml` at the root per the GitHub Actions convention.)*
+- **Tooling** lives in dot-prefixed folders — `.github/` (workflows, instructions), `.scripts/`, `.devcontainer/`, `.docker/`, `.config/`, `.vscode/`.
+- **Additional documentation** beyond the root `README.md` lives as Markdown under `docs/`.
+- **`.gitattributes`** standardises line endings across Windows/Linux. Use:
+
+  ```gitattributes
+  * text=auto eol=lf
+  *.{cmd,[cC][mM][dD]} text eol=crlf
+  *.{bat,[bB][aA][tT]} text eol=crlf
+  ```
+
+- **`.editorconfig`** is the single source of truth for indentation, line endings, and analyzer/formatting rules.
+- **`GitVersion.yml`** in the root drives semantic-versioning rules.
+
 ## Misc
 
 - When detecting new conventions or patterns in the codebase, add them to the appropriate `.github/instructions/*.instructions.md` file (or this file for cross-cutting workflow rules) and apply them retroactively where applicable.

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,0 +1,50 @@
+---
+description: 'README consistency and Mermaid diagram conventions for Markdown documentation.'
+applyTo: '**/*.md'
+---
+
+# Documentation
+
+## README Consistency
+
+- Every project's `README.md` must stay in sync with its implementation. During any refactoring — and **always** before creating a new PR — scan the `README.md` for inconsistencies: outdated input/output names, missing or removed configuration options, or inaccurate examples. Update the README as part of the same change, not as a follow-up.
+- **Markdown tables**: Table separator rows must use spaces around pipes to match the spaced style used in header and data rows (e.g. `| --- | --- |` not `|---|---|`). This prevents MD060 (table-column-style) warnings.
+
+## Mermaid Diagrams
+
+Use Mermaid diagrams in `README.md` files to visualize complex relationships and flows. Choose the appropriate diagram type:
+
+### Diagram Type Selection
+
+- **`flowchart`**: Sequential processes, data flow, event flow, service orchestration, CI/CD pipelines
+  - Direction: Use `TD` (top-down) for vertical flows; `LR` (left-right) for wide workflows
+  - Example: GitHub Actions workflow chains, composite action steps
+
+- **`graph`**: Relationships, dependencies, hierarchies (non-sequential)
+  - Direction: Use `TD` for dependency trees; `LR` for peer relationships
+  - Example: Action dependencies, workflow call chains
+
+### Standard Headings
+
+Use these consistent heading patterns before Mermaid diagrams:
+
+| Heading | Use For |
+| --- | --- |
+| `## Deployment Flow` | CI/CD pipelines, GitHub Actions workflows, action call chains |
+| `## Dependency Graph` | Action dependencies, workflow relationships |
+
+### Styling Guidelines
+
+- **Subgraphs**: Group related steps or jobs
+- **Custom styling**: Define `classDef` for highlighting owned vs. third-party actions
+- **Node shapes**:
+  - `[ ]` rectangle (default) - actions, jobs
+  - `([ ])` stadium - workflows
+  - `{ }` diamond - decision points
+
+### Synchronization
+
+- Mermaid diagrams must stay in sync with action/workflow changes
+- When renaming inputs/outputs, update corresponding diagram nodes
+- When adding/removing action dependencies, update dependency graphs
+- Review all `README.md` diagrams before creating PRs

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,0 +1,58 @@
+---
+description: 'GitHub Actions workflow and composite-action conventions — naming, YAML style, security and GitVersion.'
+applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
+---
+
+# GitHub Actions
+
+## General
+
+- Always leave **one blank line between steps** within a job for readability.
+- Pin actions to the **major version tag version by default** (e.g. `actions/checkout@v6`, `softprops/action-gh-release@v2`). Do not use SHA pinning or include minor/patch versions.
+- Set `fetch-depth: 0` on `actions/checkout` whenever GitVersion is used so it can read the full commit history. For lint-only workflows where history is unnecessary, `fetch-depth: 1` is acceptable.
+- Use explicit `permissions` blocks on every job; default to the minimum required (e.g. `contents: read`). Set global workflow-level permissions to `permissions: {}` (deny all) and grant per-job.
+
+## Step Naming
+
+- **One-liners**: When a step's `run` block is a single command, use that command (or a slightly abbreviated form) as the step `name` rather than a descriptive prose label (e.g. `name: npm install --global json5`, not `name: setup json5`).
+- **Multi-part setup**: When a setup requires multiple steps, name each step with a `(N of M)` suffix (e.g. `name: setup yq (1 of 3)`, `name: setup yq (2 of 3)`, `name: setup yq (3 of 3)`).
+- **Matrix-based names**: Include matrix variables in step names for identification (e.g. `name: test (${{ matrix.gv-source }}, ${{ matrix.gv-config }})`).
+
+## Naming Conventions
+
+- **Inputs/outputs**: kebab-case (e.g. `image-registry`, `tag-override`, `git-user-name`).
+- **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
+- **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
+
+## YAML Style
+
+- **2-space indentation** for all workflow and action YAML files.
+- Do not quote strings unless YAML requires it (e.g. values containing special characters, reserved words like `true`/`false`/`null`, or strings that could be misinterpreted as another type).
+- For `workflow_dispatch` string inputs that represent booleans, use quoted defaults (e.g. `default: 'true'`).
+- Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
+- One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
+
+## Reusable Workflows
+
+- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
+- **Same repo**: `uses: ./.github/workflows/_filename.yml`
+- **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
+- Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.
+
+## Composite Actions
+
+- Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
+- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
+
+## Security
+
+- Deny all permissions at workflow level (`permissions: {}`), grant only what each job requires.
+- Skip bot-triggered runs conditionally: `if: github.actor != 'dependabot[bot]'`.
+- Pass tokens via `stdin` for registry logins (e.g. `echo "$TOKEN" | docker login --password-stdin`).
+- OCI registry, repository and tag values must be forced to lowercase (e.g. `${IMAGE_REGISTRY,,}`).
+
+## GitVersion
+
+- Always set `fetch-depth: 0` on checkout when GitVersion is in use.
+- Default config file is `GitVersion.yml` in the repository root.
+- Prefer `semVer` for tags and releases; use `fullSemVer` (via the `version` output) for build versioning and pre-release identifiers.

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -32,9 +32,17 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 - Use `|` (pipe) for multi-line `run` scripts. Use `>` for flowing multi-line description text.
 - One blank line between major YAML sections (`on:`, `env:`, `jobs:`). No blank lines within input/output lists.
 
+## Reusability
+
+- **Reusability is a key requirement.** Factor cross-cutting GitHub Actions logic (build, test, lint, versioning, container/Helm packaging, EF migration-drift checks, etc.) into reusable `workflow_call` workflows in the `f2calv/gha-workflows` repo wherever it makes sense, so every repository consumes one implementation. Keep logic inline or in a repo-local reusable workflow only when it is genuinely repo-specific and unlikely to be reused.
+- **`gha-workflows` is the ideal home** for shared workflows. Parameterize them with `inputs` (paths, project/context names, configuration, flags) so they stay repo-agnostic; a consumer passes specifics via `with:`.
+- **Filename convention differs by scope:**
+  - *Shared* (cross-repo, in `gha-workflows`): non-underscore filename with a `_`-prefixed `name:` (e.g. file `app-build-dotnet.yml`, `name: _app-build-dotnet`), consumed via `uses: f2calv/gha-workflows/.github/workflows/<file>.yml@v1`.
+  - *Local* (same-repo): underscore-prefixed filename (e.g. `_gitops-helm-update.yml`), consumed via `uses: ./.github/workflows/_filename.yml`.
+
 ## Reusable Workflows
 
-- **File naming**: Prefix reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
+- **File naming**: Prefix local (same-repo) reusable workflow filenames with an underscore to distinguish them from top-level entry-point workflows (e.g. `_gitops-helm-update.yml`, `_deploy-maui-android.yml`).
 - **Same repo**: `uses: ./.github/workflows/_filename.yml`
 - **Cross-repo**: `uses: owner/repo/.github/workflows/filename.yml@v1`
 - Prefer `secrets: inherit` unless there is a specific reason to restrict secrets passed to the called workflow.

--- a/.github/workflows/_deploy-maui-android.yml
+++ b/.github/workflows/_deploy-maui-android.yml
@@ -56,7 +56,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/app-build-dotnet.yml
+++ b/.github/workflows/app-build-dotnet.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     #if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/app-build-rust.yml
+++ b/.github/workflows/app-build-rust.yml
@@ -12,7 +12,7 @@ jobs:
   app-build-rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -74,7 +74,7 @@ jobs:
     #https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
     #https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dotnet-publish-nuget.yml
+++ b/.github/workflows/dotnet-publish-nuget.yml
@@ -70,7 +70,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   needs: [build]
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@v7
   #       with:
   #         fetch-depth: 0
   #

--- a/.github/workflows/ef-migrations-drift.yml
+++ b/.github/workflows/ef-migrations-drift.yml
@@ -1,0 +1,69 @@
+name: _ef-migrations-drift
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        type: string
+        description: Migrations/target project or solution (e.g. src/CasCap.Data/CasCap.Data.csproj)
+        required: true
+      startup-project:
+        type: string
+        description: Design-time startup project (defaults to `project` when empty)
+        default: ''
+      context:
+        type: string
+        description: DbContext name (optional; omit when the project has a single context)
+        default: ''
+      configuration:
+        type: string
+        description: e.g. Debug or Release
+        default: Release
+      extra-repos:
+        type: string
+        description: >
+          JSON array of extra repositories to clone (Debug builds with sibling ProjectReferences).
+          Each element: {"repo":"owner/name","ref":"main","path":"deps/name"}
+        default: '[]'
+
+jobs:
+  ef-migrations-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: clone extra repositories
+        if: inputs.extra-repos != '[]'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXTRA_REPOS: ${{ inputs.extra-repos }}
+        run: |
+          echo "$EXTRA_REPOS" | jq -c '.[]' | while read -r item; do
+            REPO=$(echo "$item" | jq -r '.repo')
+            REF=$(echo "$item" | jq -r '.ref // "HEAD"')
+            DEST=$(echo "$item" | jq -r '.path // "deps"')
+            git clone --depth 1 --branch "$REF" \
+              "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$DEST"
+          done
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: dotnet tool restore
+        run: dotnet tool restore
+
+      - name: dotnet ef migrations has-pending-model-changes
+        run: >
+          dotnet ef migrations has-pending-model-changes
+          --project ${{ inputs.project }}
+          --startup-project ${{ inputs.startup-project != '' && inputs.startup-project || inputs.project }}
+          ${{ inputs.context != '' && format('--context {0}', inputs.context) || '' }}
+          --configuration ${{ inputs.configuration }}

--- a/.github/workflows/gha-gitops-manifest-update.yml
+++ b/.github/workflows/gha-gitops-manifest-update.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           repository: ${{ inputs.gitops-repo }}

--- a/.github/workflows/gha-release-versioning.yml
+++ b/.github/workflows/gha-release-versioning.yml
@@ -66,7 +66,7 @@ jobs:
       patch: ${{ steps.gha-release-versioning.outputs.patch }}
       release-exists: ${{ steps.gha-release-versioning.outputs.release-exists }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-chart-package.yml
+++ b/.github/workflows/helm-chart-package.yml
@@ -58,7 +58,7 @@ jobs:
   helm-chart-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -1,0 +1,50 @@
+name: _package-cleanup
+
+on:
+  workflow_call:
+    inputs:
+      packages:
+        type: string
+        description: Comma-separated list of ghcr.io package names to prune, e.g. my-app,my-app/charts/my-chart
+        required: true
+      keep-n-tagged:
+        type: number
+        description: Number of most-recent tagged versions to retain per package.
+        default: 10
+      exclude-tags:
+        type: string
+        description: Tags to always preserve (wildcard syntax). Takes priority over every other rule.
+        default: latest
+      older-than:
+        type: string
+        description: Only delete images older than this interval, e.g. '30 days', '6 months'. Empty disables the age filter.
+        default: ''
+      delete-untagged:
+        type: boolean
+        description: Delete all untagged (orphaned) images.
+        default: true
+      dry-run:
+        type: boolean
+        description: Log everything that would be deleted without making changes.
+        default: true
+
+permissions: {}
+
+jobs:
+  package-cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    concurrency:
+      group: package-cleanup-${{ github.repository }}
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          owner: ${{ github.repository_owner }}
+          packages: ${{ inputs.packages }}
+          keep-n-tagged: ${{ inputs.keep-n-tagged }}
+          exclude-tags: ${{ inputs.exclude-tags }}
+          older-than: ${{ inputs.older-than }}
+          delete-untagged: ${{ inputs.delete-untagged }}
+          dry-run: ${{ inputs.dry-run }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
 | [Container Image Build](.github/workflows/container-image-build.yml) | Multi-architecture buildx build and push to a container registry (ghcr.io, ACR, Docker Hub). Tags with semver, major, minor and latest. Optionally clones extra repositories into the Docker build context. | `registry` (required), `tag` (required), `tag-major` (required), `tag-minor` (required), `platform`, `dockerfile`, `push-image`, `extra-repos` |
 | [Helm Chart Package](.github/workflows/helm-chart-package.yml) | Lint, package and push a Helm chart to an OCI registry. Helm version is sourced from `.devcontainer/devcontainer.json`. | `tag` (required), `image-registry` (required), `chart-registry` (required), `chart-repository` (required), `chart-path` |
 | [GitOps Manifest Update](.github/workflows/gha-gitops-manifest-update.yml) | Update image tags in a GitOps repository via [f2calv/gha-gitops-manifest-update](https://github.com/f2calv/gha-gitops-manifest-update). | `tag` (required), `image-registry` (required), `image-repository` (required), `manifest-paths` (required), `namespace` (required) |
+| [Package Cleanup](.github/workflows/package-cleanup.yml) | Prune old container/Helm chart versions from ghcr.io via [dataaxiom/ghcr-cleanup-action](https://github.com/dataaxiom/ghcr-cleanup-action). Keeps the N most-recent tagged versions, deletes untagged orphans, and protects excluded tags. Defaults to dry-run. | `packages` (required), `keep-n-tagged`, `exclude-tags`, `older-than`, `delete-untagged`, `dry-run` |
 
 ### NuGet
 
@@ -104,6 +105,15 @@ flowchart LR
     J --> A1["actions/checkout@v6"]
     J --> A2["f2calv/gha-gitops-manifest-update@v2"]
     class A2 f2calv
+```
+
+### _package-cleanup
+
+```mermaid
+flowchart LR
+    classDef f2calv fill:#dbeafe,stroke:#2563eb,color:#1e3a5f
+    W(["_package-cleanup"]) --> J["package-cleanup"]
+    J --> A1["dataaxiom/ghcr-cleanup-action@v1"]
 ```
 
 ### _gha-release-versioning

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ jobs:
 | [App Build .NET](.github/workflows/app-build-dotnet.yml) | Restore, workload restore, build a .NET solution/project. Installs .NET 8/9/10 SDKs. Optionally clones extra repositories into the build context. | `version` (required), `solution-name`, `configuration`, `dotnet-restore-args`, `dotnet-build-args`, `extra-repos` |
 | [App Build Rust](.github/workflows/app-build-rust.yml) | Format check, clippy lint, fetch and build a Rust project. | `version` (required) |
 
+### Database
+
+| Workflow | Description | Key Inputs |
+| --- | --- | --- |
+| [EF Migrations Drift](.github/workflows/ef-migrations-drift.yml) | Fail when the EF Core model has schema changes not captured by a migration (runs `dotnet ef migrations has-pending-model-changes`; no live database required). Installs .NET 8/9/10 SDKs and restores tools. The caller repo must pin `dotnet-ef` in `.config/dotnet-tools.json` and provide an `IDesignTimeDbContextFactory` configured with the migrations provider. | `project` (required), `startup-project`, `context`, `configuration`, `extra-repos` |
+
 ### Containers & Helm
 
 | Workflow | Description | Key Inputs |
@@ -74,6 +80,16 @@ flowchart LR
     classDef f2calv fill:#dbeafe,stroke:#2563eb,color:#1e3a5f
     W(["_app-build-rust"]) --> J["app-build-rust"]
     J --> A1["actions/checkout@v6"]
+```
+
+### _ef-migrations-drift
+
+```mermaid
+flowchart LR
+    classDef f2calv fill:#dbeafe,stroke:#2563eb,color:#1e3a5f
+    W(["_ef-migrations-drift"]) --> J["ef-migrations-drift"]
+    J --> A1["actions/checkout@v7"]
+    J --> A2["actions/setup-dotnet@v5"]
 ```
 
 ### _container-image-build


### PR DESCRIPTION
## Summary

Adds two new reusable workflows (EF migration-drift guard and ghcr package cleanup), restructures the Copilot instructions into scoped instruction files, documents a GitHub Actions reusability convention, and bumps `actions/checkout` to `v7` across all workflows.

## Changes

### New reusable workflows

- **`ef-migrations-drift.yml`** (`_ef-migrations-drift`) — generic `workflow_call` workflow that runs `dotnet ef migrations has-pending-model-changes` to fail a pipeline when the EF Core model has drifted from its migrations. DB-less (never connects), so it's cheap and safe to gate on.
  - Inputs: `project` (required), `startup-project`, `context`, `configuration` (default `Release`), `extra-repos`.
  - Mirrors `app-build-dotnet.yml` conventions: `_`-prefixed name, per-job `contents: read`, `checkout@v7`, `setup-dotnet@v5` (8/9/10), optional sibling-repo clone step.
  - Caller prerequisites: pin `dotnet-ef` in `.config/dotnet-tools.json` and provide an `IDesignTimeDbContextFactory` with the migrations provider.
- **`package-cleanup.yml`** — prunes old container/Helm chart versions from ghcr.io via `dataaxiom/ghcr-cleanup-action` (keep-N-tagged, delete untagged orphans, protect excluded tags; defaults to dry-run).

### Instructions restructure

- Split the monolithic `copilot-instructions.md` into scoped instruction files:
  - `.github/instructions/github-actions.instructions.md`
  - `.github/instructions/documentation.instructions.md`
- Added a **Reusability** convention to `github-actions.instructions.md`: reusability is a key requirement; `f2calv/gha-workflows` is the ideal home for shared workflows; clarified the shared-vs-local reusable-workflow filename convention (shared = non-underscore filename with `_`-prefixed `name:`; local = underscore-prefixed filename).

### Maintenance

- Bumped `actions/checkout@v6` → `@v7` across all workflows (`app-build-dotnet`, `app-build-rust`, `container-image-build`, `dotnet-publish-nuget`, `gha-gitops-manifest-update`, `gha-release-versioning`, `helm-chart-package`, `lint`, `_deploy-maui-android`).

### Docs

- `README.md` — documented the new `ef-migrations-drift` and `package-cleanup` workflows (Workflows tables + Deployment-Flow Mermaid blocks).

## Notes

- The `ef-migrations-drift` workflow is consumed by the CAS `deploy-all.yml` deploy pipeline (via `@v1`); the `v1` tag has been moved to include this change.
- Validation passed locally.

## Commits

- `feat: add reusable ef-migrations-drift workflow`
- `update instructions`
- `bump actions checkout`
- `package cleanup added`
- `more copilot instructions tweaks`
- `mv copilot instructions to separate files`